### PR TITLE
[Setting] Widgets Target 추가 

### DIFF
--- a/FrontyardBirds/FrontyardBirds.xcodeproj/project.pbxproj
+++ b/FrontyardBirds/FrontyardBirds.xcodeproj/project.pbxproj
@@ -13,14 +13,14 @@
 		AFF48B522C81A824005D45D9 /* FrontyardBirdsWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF48B512C81A824005D45D9 /* FrontyardBirdsWatchApp.swift */; };
 		AFF48B542C81A824005D45D9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF48B532C81A824005D45D9 /* ContentView.swift */; };
 		AFF48B562C81A826005D45D9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AFF48B552C81A826005D45D9 /* Assets.xcassets */; };
-		AFF48B5C2C81A826005D45D9 /* FrontyardBirds Watch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = AFF48B4F2C81A824005D45D9 /* FrontyardBirds Watch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		AFF48B5C2C81A826005D45D9 /* FrontyardBirds (Watch).app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = AFF48B4F2C81A824005D45D9 /* FrontyardBirds (Watch).app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		AFF48B842C81ACDD005D45D9 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AFF48B832C81ACDD005D45D9 /* WidgetKit.framework */; };
 		AFF48B862C81ACDD005D45D9 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AFF48B852C81ACDD005D45D9 /* SwiftUI.framework */; };
 		AFF48B892C81ACDD005D45D9 /* WidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF48B882C81ACDD005D45D9 /* WidgetsBundle.swift */; };
 		AFF48B8B2C81ACDD005D45D9 /* Widgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF48B8A2C81ACDD005D45D9 /* Widgets.swift */; };
 		AFF48B8D2C81ACDD005D45D9 /* AppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF48B8C2C81ACDD005D45D9 /* AppIntent.swift */; };
 		AFF48B8F2C81ACDE005D45D9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AFF48B8E2C81ACDE005D45D9 /* Assets.xcassets */; };
-		AFF48B942C81ACDE005D45D9 /* WidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = AFF48B812C81ACDD005D45D9 /* WidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		AFF48B942C81ACDE005D45D9 /* Widgets.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = AFF48B812C81ACDD005D45D9 /* Widgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,7 +47,7 @@
 			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
 			dstSubfolderSpec = 16;
 			files = (
-				AFF48B5C2C81A826005D45D9 /* FrontyardBirds Watch Watch App.app in Embed Watch Content */,
+				AFF48B5C2C81A826005D45D9 /* FrontyardBirds (Watch).app in Embed Watch Content */,
 			);
 			name = "Embed Watch Content";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -58,7 +58,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				AFF48B942C81ACDE005D45D9 /* WidgetsExtension.appex in Embed Foundation Extensions */,
+				AFF48B942C81ACDE005D45D9 /* Widgets.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -71,11 +71,11 @@
 		AFF48B282C819F8B005D45D9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		AFF48B2A2C819F8C005D45D9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AFF48B2C2C819F8C005D45D9 /* Multiplatform.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Multiplatform.entitlements; sourceTree = "<group>"; };
-		AFF48B4F2C81A824005D45D9 /* FrontyardBirds Watch Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FrontyardBirds Watch Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AFF48B4F2C81A824005D45D9 /* FrontyardBirds (Watch).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FrontyardBirds (Watch).app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AFF48B512C81A824005D45D9 /* FrontyardBirdsWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontyardBirdsWatchApp.swift; sourceTree = "<group>"; };
 		AFF48B532C81A824005D45D9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		AFF48B552C81A826005D45D9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		AFF48B812C81ACDD005D45D9 /* WidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		AFF48B812C81ACDD005D45D9 /* Widgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Widgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		AFF48B832C81ACDD005D45D9 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = /System/Library/Frameworks/WidgetKit.framework; sourceTree = "<absolute>"; };
 		AFF48B852C81ACDD005D45D9 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = /System/Library/Frameworks/SwiftUI.framework; sourceTree = "<absolute>"; };
 		AFF48B882C81ACDD005D45D9 /* WidgetsBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetsBundle.swift; sourceTree = "<group>"; };
@@ -128,8 +128,8 @@
 			isa = PBXGroup;
 			children = (
 				AFF48B232C819F8B005D45D9 /* FrontyardBirds.app */,
-				AFF48B4F2C81A824005D45D9 /* FrontyardBirds Watch Watch App.app */,
-				AFF48B812C81ACDD005D45D9 /* WidgetsExtension.appex */,
+				AFF48B4F2C81A824005D45D9 /* FrontyardBirds (Watch).app */,
+				AFF48B812C81ACDD005D45D9 /* Widgets.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -201,9 +201,9 @@
 			productReference = AFF48B232C819F8B005D45D9 /* FrontyardBirds.app */;
 			productType = "com.apple.product-type.application";
 		};
-		AFF48B4E2C81A824005D45D9 /* FrontyardBirds Watch Watch App */ = {
+		AFF48B4E2C81A824005D45D9 /* FrontyardBirds (Watch) */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = AFF48B602C81A826005D45D9 /* Build configuration list for PBXNativeTarget "FrontyardBirds Watch Watch App" */;
+			buildConfigurationList = AFF48B602C81A826005D45D9 /* Build configuration list for PBXNativeTarget "FrontyardBirds (Watch)" */;
 			buildPhases = (
 				AFF48B4B2C81A824005D45D9 /* Sources */,
 				AFF48B4C2C81A824005D45D9 /* Frameworks */,
@@ -213,14 +213,14 @@
 			);
 			dependencies = (
 			);
-			name = "FrontyardBirds Watch Watch App";
+			name = "FrontyardBirds (Watch)";
 			productName = "FrontyardBirds Watch Watch App";
-			productReference = AFF48B4F2C81A824005D45D9 /* FrontyardBirds Watch Watch App.app */;
+			productReference = AFF48B4F2C81A824005D45D9 /* FrontyardBirds (Watch).app */;
 			productType = "com.apple.product-type.application";
 		};
-		AFF48B802C81ACDD005D45D9 /* WidgetsExtension */ = {
+		AFF48B802C81ACDD005D45D9 /* Widgets */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = AFF48B982C81ACDE005D45D9 /* Build configuration list for PBXNativeTarget "WidgetsExtension" */;
+			buildConfigurationList = AFF48B982C81ACDE005D45D9 /* Build configuration list for PBXNativeTarget "Widgets" */;
 			buildPhases = (
 				AFF48B7D2C81ACDD005D45D9 /* Sources */,
 				AFF48B7E2C81ACDD005D45D9 /* Frameworks */,
@@ -230,9 +230,9 @@
 			);
 			dependencies = (
 			);
-			name = WidgetsExtension;
+			name = Widgets;
 			productName = WidgetsExtension;
-			productReference = AFF48B812C81ACDD005D45D9 /* WidgetsExtension.appex */;
+			productReference = AFF48B812C81ACDD005D45D9 /* Widgets.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
@@ -270,8 +270,8 @@
 			projectRoot = "";
 			targets = (
 				AFF48B222C819F8B005D45D9 /* FrontyardBirds */,
-				AFF48B4E2C81A824005D45D9 /* FrontyardBirds Watch Watch App */,
-				AFF48B802C81ACDD005D45D9 /* WidgetsExtension */,
+				AFF48B4E2C81A824005D45D9 /* FrontyardBirds (Watch) */,
+				AFF48B802C81ACDD005D45D9 /* Widgets */,
 			);
 		};
 /* End PBXProject section */
@@ -337,12 +337,12 @@
 /* Begin PBXTargetDependency section */
 		AFF48B5B2C81A826005D45D9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = AFF48B4E2C81A824005D45D9 /* FrontyardBirds Watch Watch App */;
+			target = AFF48B4E2C81A824005D45D9 /* FrontyardBirds (Watch) */;
 			targetProxy = AFF48B5A2C81A826005D45D9 /* PBXContainerItemProxy */;
 		};
 		AFF48B932C81ACDE005D45D9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = AFF48B802C81ACDD005D45D9 /* WidgetsExtension */;
+			target = AFF48B802C81ACDD005D45D9 /* Widgets */;
 			targetProxy = AFF48B922C81ACDE005D45D9 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -700,7 +700,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		AFF48B602C81A826005D45D9 /* Build configuration list for PBXNativeTarget "FrontyardBirds Watch Watch App" */ = {
+		AFF48B602C81A826005D45D9 /* Build configuration list for PBXNativeTarget "FrontyardBirds (Watch)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				AFF48B5E2C81A826005D45D9 /* Debug */,
@@ -709,7 +709,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		AFF48B982C81ACDE005D45D9 /* Build configuration list for PBXNativeTarget "WidgetsExtension" */ = {
+		AFF48B982C81ACDE005D45D9 /* Build configuration list for PBXNativeTarget "Widgets" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				AFF48B962C81ACDE005D45D9 /* Debug */,

--- a/FrontyardBirds/FrontyardBirds.xcodeproj/project.pbxproj
+++ b/FrontyardBirds/FrontyardBirds.xcodeproj/project.pbxproj
@@ -632,10 +632,11 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,4";
 			};
 			name = Debug;
 		};
@@ -670,10 +671,11 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,4";
 			};
 			name = Release;
 		};

--- a/FrontyardBirds/FrontyardBirds.xcodeproj/project.pbxproj
+++ b/FrontyardBirds/FrontyardBirds.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		AFF48B522C81A824005D45D9 /* FrontyardBirdsWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF48B512C81A824005D45D9 /* FrontyardBirdsWatchApp.swift */; };
 		AFF48B542C81A824005D45D9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF48B532C81A824005D45D9 /* ContentView.swift */; };
 		AFF48B562C81A826005D45D9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AFF48B552C81A826005D45D9 /* Assets.xcassets */; };
-		AFF48B5C2C81A826005D45D9 /* FrontyardBirds (Watch).app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = AFF48B4F2C81A824005D45D9 /* FrontyardBirds (Watch).app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		AFF48B5C2C81A826005D45D9 /* FrontyardBirds (Watch).app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = AFF48B4F2C81A824005D45D9 /* FrontyardBirds (Watch).app */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		AFF48B842C81ACDD005D45D9 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AFF48B832C81ACDD005D45D9 /* WidgetKit.framework */; };
 		AFF48B862C81ACDD005D45D9 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AFF48B852C81ACDD005D45D9 /* SwiftUI.framework */; };
 		AFF48B892C81ACDD005D45D9 /* WidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF48B882C81ACDD005D45D9 /* WidgetsBundle.swift */; };
@@ -337,6 +337,7 @@
 /* Begin PBXTargetDependency section */
 		AFF48B5B2C81A826005D45D9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			platformFilter = ios;
 			target = AFF48B4E2C81A824005D45D9 /* FrontyardBirds (Watch) */;
 			targetProxy = AFF48B5A2C81A826005D45D9 /* PBXContainerItemProxy */;
 		};

--- a/FrontyardBirds/FrontyardBirds.xcodeproj/project.pbxproj
+++ b/FrontyardBirds/FrontyardBirds.xcodeproj/project.pbxproj
@@ -14,6 +14,13 @@
 		AFF48B542C81A824005D45D9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF48B532C81A824005D45D9 /* ContentView.swift */; };
 		AFF48B562C81A826005D45D9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AFF48B552C81A826005D45D9 /* Assets.xcassets */; };
 		AFF48B5C2C81A826005D45D9 /* FrontyardBirds Watch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = AFF48B4F2C81A824005D45D9 /* FrontyardBirds Watch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		AFF48B842C81ACDD005D45D9 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AFF48B832C81ACDD005D45D9 /* WidgetKit.framework */; };
+		AFF48B862C81ACDD005D45D9 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AFF48B852C81ACDD005D45D9 /* SwiftUI.framework */; };
+		AFF48B892C81ACDD005D45D9 /* WidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF48B882C81ACDD005D45D9 /* WidgetsBundle.swift */; };
+		AFF48B8B2C81ACDD005D45D9 /* Widgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF48B8A2C81ACDD005D45D9 /* Widgets.swift */; };
+		AFF48B8D2C81ACDD005D45D9 /* AppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF48B8C2C81ACDD005D45D9 /* AppIntent.swift */; };
+		AFF48B8F2C81ACDE005D45D9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AFF48B8E2C81ACDE005D45D9 /* Assets.xcassets */; };
+		AFF48B942C81ACDE005D45D9 /* WidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = AFF48B812C81ACDD005D45D9 /* WidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -23,6 +30,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = AFF48B4E2C81A824005D45D9;
 			remoteInfo = "FrontyardBirds Watch Watch App";
+		};
+		AFF48B922C81ACDE005D45D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AFF48B1B2C819F8B005D45D9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AFF48B802C81ACDD005D45D9;
+			remoteInfo = WidgetsExtension;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -38,6 +52,17 @@
 			name = "Embed Watch Content";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AFF48B952C81ACDE005D45D9 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				AFF48B942C81ACDE005D45D9 /* WidgetsExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -50,6 +75,15 @@
 		AFF48B512C81A824005D45D9 /* FrontyardBirdsWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontyardBirdsWatchApp.swift; sourceTree = "<group>"; };
 		AFF48B532C81A824005D45D9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		AFF48B552C81A826005D45D9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		AFF48B812C81ACDD005D45D9 /* WidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		AFF48B832C81ACDD005D45D9 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = /System/Library/Frameworks/WidgetKit.framework; sourceTree = "<absolute>"; };
+		AFF48B852C81ACDD005D45D9 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = /System/Library/Frameworks/SwiftUI.framework; sourceTree = "<absolute>"; };
+		AFF48B882C81ACDD005D45D9 /* WidgetsBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetsBundle.swift; sourceTree = "<group>"; };
+		AFF48B8A2C81ACDD005D45D9 /* Widgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Widgets.swift; sourceTree = "<group>"; };
+		AFF48B8C2C81ACDD005D45D9 /* AppIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntent.swift; sourceTree = "<group>"; };
+		AFF48B8E2C81ACDE005D45D9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		AFF48B902C81ACDE005D45D9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AFF48B912C81ACDE005D45D9 /* Widgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Widgets.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,6 +101,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AFF48B7E2C81ACDD005D45D9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AFF48B862C81ACDD005D45D9 /* SwiftUI.framework in Frameworks */,
+				AFF48B842C81ACDD005D45D9 /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -75,6 +118,8 @@
 			children = (
 				AFF48B252C819F8B005D45D9 /* Multiplatform */,
 				AFF48B502C81A824005D45D9 /* Watch */,
+				AFF48B872C81ACDD005D45D9 /* Widgets */,
+				AFF48B822C81ACDD005D45D9 /* Frameworks */,
 				AFF48B242C819F8B005D45D9 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -84,6 +129,7 @@
 			children = (
 				AFF48B232C819F8B005D45D9 /* FrontyardBirds.app */,
 				AFF48B4F2C81A824005D45D9 /* FrontyardBirds Watch Watch App.app */,
+				AFF48B812C81ACDD005D45D9 /* WidgetsExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -109,6 +155,28 @@
 			path = Watch;
 			sourceTree = "<group>";
 		};
+		AFF48B822C81ACDD005D45D9 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				AFF48B832C81ACDD005D45D9 /* WidgetKit.framework */,
+				AFF48B852C81ACDD005D45D9 /* SwiftUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		AFF48B872C81ACDD005D45D9 /* Widgets */ = {
+			isa = PBXGroup;
+			children = (
+				AFF48B882C81ACDD005D45D9 /* WidgetsBundle.swift */,
+				AFF48B8A2C81ACDD005D45D9 /* Widgets.swift */,
+				AFF48B8C2C81ACDD005D45D9 /* AppIntent.swift */,
+				AFF48B8E2C81ACDE005D45D9 /* Assets.xcassets */,
+				AFF48B902C81ACDE005D45D9 /* Info.plist */,
+				AFF48B912C81ACDE005D45D9 /* Widgets.entitlements */,
+			);
+			path = Widgets;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -120,11 +188,13 @@
 				AFF48B202C819F8B005D45D9 /* Frameworks */,
 				AFF48B212C819F8B005D45D9 /* Resources */,
 				AFF48B5D2C81A826005D45D9 /* Embed Watch Content */,
+				AFF48B952C81ACDE005D45D9 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				AFF48B5B2C81A826005D45D9 /* PBXTargetDependency */,
+				AFF48B932C81ACDE005D45D9 /* PBXTargetDependency */,
 			);
 			name = FrontyardBirds;
 			productName = FrontyardBirds;
@@ -148,6 +218,23 @@
 			productReference = AFF48B4F2C81A824005D45D9 /* FrontyardBirds Watch Watch App.app */;
 			productType = "com.apple.product-type.application";
 		};
+		AFF48B802C81ACDD005D45D9 /* WidgetsExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AFF48B982C81ACDE005D45D9 /* Build configuration list for PBXNativeTarget "WidgetsExtension" */;
+			buildPhases = (
+				AFF48B7D2C81ACDD005D45D9 /* Sources */,
+				AFF48B7E2C81ACDD005D45D9 /* Frameworks */,
+				AFF48B7F2C81ACDD005D45D9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = WidgetsExtension;
+			productName = WidgetsExtension;
+			productReference = AFF48B812C81ACDD005D45D9 /* WidgetsExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -162,6 +249,9 @@
 						CreatedOnToolsVersion = 15.4;
 					};
 					AFF48B4E2C81A824005D45D9 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+					AFF48B802C81ACDD005D45D9 = {
 						CreatedOnToolsVersion = 15.4;
 					};
 				};
@@ -181,6 +271,7 @@
 			targets = (
 				AFF48B222C819F8B005D45D9 /* FrontyardBirds */,
 				AFF48B4E2C81A824005D45D9 /* FrontyardBirds Watch Watch App */,
+				AFF48B802C81ACDD005D45D9 /* WidgetsExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -199,6 +290,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				AFF48B562C81A826005D45D9 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AFF48B7F2C81ACDD005D45D9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AFF48B8F2C81ACDE005D45D9 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -223,6 +322,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AFF48B7D2C81ACDD005D45D9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AFF48B892C81ACDD005D45D9 /* WidgetsBundle.swift in Sources */,
+				AFF48B8B2C81ACDD005D45D9 /* Widgets.swift in Sources */,
+				AFF48B8D2C81ACDD005D45D9 /* AppIntent.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -230,6 +339,11 @@
 			isa = PBXTargetDependency;
 			target = AFF48B4E2C81A824005D45D9 /* FrontyardBirds Watch Watch App */;
 			targetProxy = AFF48B5A2C81A826005D45D9 /* PBXContainerItemProxy */;
+		};
+		AFF48B932C81ACDE005D45D9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AFF48B802C81ACDD005D45D9 /* WidgetsExtension */;
+			targetProxy = AFF48B922C81ACDE005D45D9 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -487,6 +601,82 @@
 			};
 			name = Release;
 		};
+		AFF48B962C81ACDE005D45D9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = Widgets/Widgets.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = ZWTS2P7AH7;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Widgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Widgets;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onemorethink.FrontyardBirds.Widgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		AFF48B972C81ACDE005D45D9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = Widgets/Widgets.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = ZWTS2P7AH7;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Widgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Widgets;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onemorethink.FrontyardBirds.Widgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -513,6 +703,15 @@
 			buildConfigurations = (
 				AFF48B5E2C81A826005D45D9 /* Debug */,
 				AFF48B5F2C81A826005D45D9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AFF48B982C81ACDE005D45D9 /* Build configuration list for PBXNativeTarget "WidgetsExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AFF48B962C81ACDE005D45D9 /* Debug */,
+				AFF48B972C81ACDE005D45D9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/FrontyardBirds/FrontyardBirds.xcodeproj/xcshareddata/xcschemes/FrontyardBirds (Watch).xcscheme
+++ b/FrontyardBirds/FrontyardBirds.xcodeproj/xcshareddata/xcschemes/FrontyardBirds (Watch).xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AFF48B4E2C81A824005D45D9"
+               BuildableName = "FrontyardBirds (Watch).app"
+               BlueprintName = "FrontyardBirds (Watch)"
+               ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AFF48B222C819F8B005D45D9"
+               BuildableName = "FrontyardBirds.app"
+               BlueprintName = "FrontyardBirds"
+               ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AFF48B4E2C81A824005D45D9"
+            BuildableName = "FrontyardBirds (Watch).app"
+            BlueprintName = "FrontyardBirds (Watch)"
+            ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AFF48B4E2C81A824005D45D9"
+            BuildableName = "FrontyardBirds (Watch).app"
+            BlueprintName = "FrontyardBirds (Watch)"
+            ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FrontyardBirds/FrontyardBirds.xcodeproj/xcshareddata/xcschemes/FrontyardBirds.xcscheme
+++ b/FrontyardBirds/FrontyardBirds.xcodeproj/xcshareddata/xcschemes/FrontyardBirds.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AFF48B222C819F8B005D45D9"
+               BuildableName = "FrontyardBirds.app"
+               BlueprintName = "FrontyardBirds"
+               ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AFF48B222C819F8B005D45D9"
+            BuildableName = "FrontyardBirds.app"
+            BlueprintName = "FrontyardBirds"
+            ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AFF48B222C819F8B005D45D9"
+            BuildableName = "FrontyardBirds.app"
+            BlueprintName = "FrontyardBirds"
+            ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FrontyardBirds/FrontyardBirds.xcodeproj/xcshareddata/xcschemes/Widgets (Multiplatform).xcscheme
+++ b/FrontyardBirds/FrontyardBirds.xcodeproj/xcshareddata/xcschemes/Widgets (Multiplatform).xcscheme
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AFF48B802C81ACDD005D45D9"
+               BuildableName = "Widgets.appex"
+               BlueprintName = "Widgets"
+               ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AFF48B222C819F8B005D45D9"
+               BuildableName = "FrontyardBirds.app"
+               BlueprintName = "FrontyardBirds"
+               ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AFF48B222C819F8B005D45D9"
+            BuildableName = "FrontyardBirds.app"
+            BlueprintName = "FrontyardBirds"
+            ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "_XCWidgetKind"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetDefaultView"
+            value = "timeline"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetFamily"
+            value = "systemMedium"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AFF48B222C819F8B005D45D9"
+            BuildableName = "FrontyardBirds.app"
+            BlueprintName = "FrontyardBirds"
+            ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FrontyardBirds/FrontyardBirds.xcodeproj/xcshareddata/xcschemes/Widgets (Watch).xcscheme
+++ b/FrontyardBirds/FrontyardBirds.xcodeproj/xcshareddata/xcschemes/Widgets (Watch).xcscheme
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AFF48B802C81ACDD005D45D9"
+               BuildableName = "Widgets.appex"
+               BlueprintName = "Widgets"
+               ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AFF48B222C819F8B005D45D9"
+               BuildableName = "FrontyardBirds.app"
+               BlueprintName = "FrontyardBirds"
+               ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AFF48B222C819F8B005D45D9"
+            BuildableName = "FrontyardBirds.app"
+            BlueprintName = "FrontyardBirds"
+            ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "_XCWidgetKind"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetDefaultView"
+            value = "timeline"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetFamily"
+            value = "systemMedium"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AFF48B222C819F8B005D45D9"
+            BuildableName = "FrontyardBirds.app"
+            BlueprintName = "FrontyardBirds"
+            ReferencedContainer = "container:FrontyardBirds.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FrontyardBirds/Widgets/AppIntent.swift
+++ b/FrontyardBirds/Widgets/AppIntent.swift
@@ -1,0 +1,18 @@
+//
+//  AppIntent.swift
+//  Widgets
+//
+//  Created by 이종선 on 8/30/24.
+//
+
+import WidgetKit
+import AppIntents
+
+struct ConfigurationAppIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource = "Configuration"
+    static var description = IntentDescription("This is an example widget.")
+
+    // An example configurable parameter.
+    @Parameter(title: "Favorite Emoji", default: "😃")
+    var favoriteEmoji: String
+}

--- a/FrontyardBirds/Widgets/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/FrontyardBirds/Widgets/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FrontyardBirds/Widgets/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/FrontyardBirds/Widgets/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,63 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FrontyardBirds/Widgets/Assets.xcassets/Contents.json
+++ b/FrontyardBirds/Widgets/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FrontyardBirds/Widgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/FrontyardBirds/Widgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FrontyardBirds/Widgets/Info.plist
+++ b/FrontyardBirds/Widgets/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/FrontyardBirds/Widgets/Widgets.entitlements
+++ b/FrontyardBirds/Widgets/Widgets.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>

--- a/FrontyardBirds/Widgets/Widgets.entitlements
+++ b/FrontyardBirds/Widgets/Widgets.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.onemorethink.FrontyardBirds</string>
+	</array>
 </dict>
 </plist>

--- a/FrontyardBirds/Widgets/Widgets.swift
+++ b/FrontyardBirds/Widgets/Widgets.swift
@@ -1,0 +1,82 @@
+//
+//  Widgets.swift
+//  Widgets
+//
+//  Created by 이종선 on 8/30/24.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct Provider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: ConfigurationAppIntent())
+    }
+
+    func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: configuration)
+    }
+    
+    func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<SimpleEntry> {
+        var entries: [SimpleEntry] = []
+
+        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
+        let currentDate = Date()
+        for hourOffset in 0 ..< 5 {
+            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
+            let entry = SimpleEntry(date: entryDate, configuration: configuration)
+            entries.append(entry)
+        }
+
+        return Timeline(entries: entries, policy: .atEnd)
+    }
+}
+
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+    let configuration: ConfigurationAppIntent
+}
+
+struct WidgetsEntryView : View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        Text("Time:")
+        Text(entry.date, style: .time)
+
+        Text("Favorite Emoji:")
+        Text(entry.configuration.favoriteEmoji)
+    }
+}
+
+struct Widgets: Widget {
+    let kind: String = "Widgets"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
+            WidgetsEntryView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+    }
+}
+
+extension ConfigurationAppIntent {
+    fileprivate static var smiley: ConfigurationAppIntent {
+        let intent = ConfigurationAppIntent()
+        intent.favoriteEmoji = "😀"
+        return intent
+    }
+    
+    fileprivate static var starEyes: ConfigurationAppIntent {
+        let intent = ConfigurationAppIntent()
+        intent.favoriteEmoji = "🤩"
+        return intent
+    }
+}
+
+#Preview(as: .systemSmall) {
+    Widgets()
+} timeline: {
+    SimpleEntry(date: .now, configuration: .smiley)
+    SimpleEntry(date: .now, configuration: .starEyes)
+}

--- a/FrontyardBirds/Widgets/WidgetsBundle.swift
+++ b/FrontyardBirds/Widgets/WidgetsBundle.swift
@@ -1,0 +1,16 @@
+//
+//  WidgetsBundle.swift
+//  Widgets
+//
+//  Created by 이종선 on 8/30/24.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct WidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        Widgets()
+    }
+}


### PR DESCRIPTION
- Widgets Target을 추가했습니다. 
- 추가된 Widget Target의 Supported Destination에 watchOS를 추가했습니다.
- 각 Target의 이름을 변경했습니다.
- 변경된 Target 이름에 맞는 scheme을 새로 만들었습니다. 
- Widget Target에 대하여 Entitlement : App Groups를 추가하고 각 플렛폼에 대한 식별자를 지정해주었습니다. 
- App Target의 Embed Watch Contents를 변경했습니다. 

> Multiplatform app 개발시 Embed Watch Contents 에 WatchOS와 호환되지 않는 macOS가 포함되지 않도록 해야합니다. 